### PR TITLE
Feature: Set configs of plugin modules in package.json

### DIFF
--- a/packages/tcore-api/src/Services/Plugins.ts
+++ b/packages/tcore-api/src/Services/Plugins.ts
@@ -305,11 +305,13 @@ export async function getPluginInfo(id: TGenericID): Promise<IPlugin | null> {
   const mainSettings = await getMainSettings();
   const settings = await getPluginSettings(id);
 
-  const modules = [...plugin.modules.values()].map((module) => {
+  const modules: any[] = [];
+
+  for (const module of [...plugin.modules.values()]) {
     const moduleSettings = settings?.modules?.find((y) => y.id === module.setup.id);
     const moduleValues = moduleSettings?.values || {};
 
-    const moduleFields = flattenConfigFields(module.setup.configs || []);
+    const moduleFields = flattenConfigFields(await module.getConfigDefinitions());
     for (const field of moduleFields) {
       // we override the default value of the config field to use the last
       // inserted value or the actual default from the module configuration
@@ -322,13 +324,13 @@ export async function getPluginInfo(id: TGenericID): Promise<IPlugin | null> {
       }
     }
 
-    return {
+    modules.push({
       ...module.setup,
       error: module.error,
       message: module.message,
       state: module.state,
-    };
-  });
+    });
+  }
 
   const dbPluginID = String(mainSettings.database_plugin).split(":")[0];
   const allow_disable = dbPluginID !== id;

--- a/packages/tcore-api/src/Services/Settings.ts
+++ b/packages/tcore-api/src/Services/Settings.ts
@@ -197,7 +197,7 @@ export async function setPluginModulesSettings(id: string, values: any) {
 
   for (const item of values) {
     const module = plugin?.modules?.get(item.moduleID);
-    const configs = flattenConfigFields(module?.setup.configs || []);
+    const configs = flattenConfigFields((await module?.getConfigDefinitions()) || []);
     const field = configs.find((x) => "field" in x && x.field === item.field);
     const isPassword = field?.type === "password";
 

--- a/packages/tcore-console/src/Components/Icon/Icon.types.ts
+++ b/packages/tcore-console/src/Components/Icon/Icon.types.ts
@@ -6,7 +6,7 @@
  * Types of icons available in the system.
  * Each one must match the corresponding filename in the /assets/icons folder.
  */
- enum EIcon {
+enum EIcon {
   "alpine" = "alpine",
   "apple" = "apple",
   "arrow-alt-circle-down" = "arrow-alt-circle-down",


### PR DESCRIPTION
This PR changes the way `configs` of plugins are informed. Now they must be informed in of `tcore.configs.[module]` in the package.json of the plugin.

The reason for the change is because Tcore cannot read the configs before executing the plugin code, since the configs are inside of the code of the plugin.